### PR TITLE
01 bug on preview image

### DIFF
--- a/app/views/shared/_media_image.html.slim
+++ b/app/views/shared/_media_image.html.slim
@@ -1,6 +1,6 @@
 ruby:
   medium = local_assigns[:medium]
 
-.media-image
-  - if medium.name.present?
+- if medium.image_url
+  .media-image
     = image_tag medium.image_url(:lg)

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -28,9 +28,6 @@
 
 FactoryBot.define do
   factory :article do
-    sequence(:title){ 'test_title_1' }
-    slug 'test_slug'
-    body 'test_body'
-    state :draft
+
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -28,6 +28,9 @@
 
 FactoryBot.define do
   factory :article do
-    
+    sequence(:title){ 'test_title_1' }
+    slug 'test_slug'
+    body 'test_body'
+    state :draft
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,6 +18,11 @@
 
 FactoryBot.define do
   factory :user do
-    
+    sequence(:name){ 'test_name_1' }
+    role :writer
+
+    trait :admin do
+      role :admin
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,11 +18,24 @@
 
 FactoryBot.define do
   factory :user do
-    sequence(:name){ 'test_name_1' }
-    role :writer
+    sequence(:name) { |n| "user-#{n}" }
+    password { 'password' }
+    password_confirmation { 'password' }
+    role { :writer }
 
     trait :admin do
-      role :admin
+      sequence(:name) { |n| "admin-#{n}" }
+      role { :admin }
+    end
+
+    trait :editor do
+      sequence(:name) { |n| "editor-#{n}"}
+      role { :editor }
+    end
+
+    trait :writer do
+      sequence(:name) { |n| "writer-#{n}"}
+      role { :writer }
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,4 +60,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # FactoryBotの省略
+  config.include FactoryBot::Syntax::Methods
+
+  # spec/support/ 配下のモジュールを読み込む
+  config.include LoginMacros
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,4 +93,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  config.before :suite do
+    SeedFu.seed
+  end
 end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,8 +1,9 @@
 module LoginMacros
-  def login_as(user)
-    visit admin_login_identifier
+  def login(user)
+    visit admin_login_identifier_path
     fill_in 'user[name]',	with: user.name
     click_button '次へ'
     fill_in 'user[password]',	with: 'password'
     click_button 'ログイン'
   end
+end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,0 +1,8 @@
+module LoginMacros
+  def login_as(user)
+    visit admin_login_identifier
+    fill_in 'user[name]',	with: user.name
+    click_button '次へ'
+    fill_in 'user[password]',	with: 'password'
+    click_button 'ログイン'
+  end

--- a/spec/system/admin_articles_previews_spec.rb
+++ b/spec/system/admin_articles_previews_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe "AdminArticlesPreviews", type: :system do
+  let(:admin){ create(:user, :admin) }
+  before{ login_as(admin) }
+
+  let(:article){ create(:article) }
+
+  describe '記事作成画面で画像ブロックを追加' do
+    describe 'プレビュー' do
+      context "画像を添付しないでプレビュー " do
+        it '正常にプレビューページが表示される' , focus:true do
+          click_link '記事'
+          click_link '新規作成'
+          fill_in 'タイトル', with: '記事タイトル'
+          fill_in 'スラッグ', with: 'test'
+          fill_in '概要',	with: '記事概要'
+          click_button '登録する'
+          click_link 'ブロックを追加する'
+          click_on '画像'
+          click_link 'プレビュー'
+          switch_to_window(windows.last)
+          expect(page).to have_content '記事タイトル'
+        end
+      end
+    end
+  end
+end

--- a/spec/system/admin_articles_previews_spec.rb
+++ b/spec/system/admin_articles_previews_spec.rb
@@ -1,27 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe "AdminArticlesPreviews", type: :system do
-  let(:admin){ create(:user, :admin) }
-  before{ login_as(admin) }
-
-  let(:article){ create(:article) }
+  let(:admin) { create(:user, :admin) }
 
   describe '記事作成画面で画像ブロックを追加' do
-    describe 'プレビュー' do
-      context "画像を添付しないでプレビュー " do
-        it '正常にプレビューページが表示される' , focus:true do
-          click_link '記事'
-          click_link '新規作成'
-          fill_in 'タイトル', with: '記事タイトル'
-          fill_in 'スラッグ', with: 'test'
-          fill_in '概要',	with: '記事概要'
-          click_button '登録する'
-          click_link 'ブロックを追加する'
-          click_on '画像'
-          click_link 'プレビュー'
-          switch_to_window(windows.last)
-          expect(page).to have_content '記事タイトル'
-        end
+    context '画像を添付せずにプレビューを閲覧' do
+      it '正常に表示される' do
+        login(admin)
+        click_link '記事'
+        click_link '新規作成'
+        fill_in 'タイトル', with: 'テスト記事'
+        fill_in 'スラッグ', with: 'test'
+        fill_in '概要',	with: '記事概要'
+        click_button '登録する'
+        click_link 'ブロックを追加する'
+        click_link '画像'
+        click_link 'プレビュー'
+        switch_to_window(windows.last)
+        expect(page).to have_content 'テスト記事'
       end
     end
   end


### PR DESCRIPTION
概要
- 記事に画像のコンテンツブロックを挿入後、画像ファイルをアップロードせずにプレビューページを閲覧または公開すると発生するエラーを修正
- 上記修正のSpecを作成