### PR TITLE
02 breadcrumb

### DIFF
--- a/app/views/admin/tags/edit.html.slim
+++ b/app/views/admin/tags/edit.html.slim
@@ -1,6 +1,8 @@
 = content_for 'content-header' do
   | タグ編集
 
+- breadcrumb :edit_admin_tag, @tag
+
 .box
   = render 'form', tag: @tag
 

--- a/app/views/admin/tags/index.html.slim
+++ b/app/views/admin/tags/index.html.slim
@@ -1,6 +1,8 @@
 = content_for 'content-header' do
   | タグ
 
+- breadcrumb :admin_tags
+
 .row
   .col-md-9
     .box.box-primary

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -99,5 +99,5 @@ end
 
 crumb :edit_admin_tag do |tag|
   link 'タグ編集', edit_admin_tag_path(tag)
-  parent :admin_dashboard
+  parent :admin_tags
 end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -91,3 +91,13 @@ crumb :edit_admin_article do |article|
   link '記事編集', edit_admin_article_path(article.uuid)
   parent :admin_articles
 end
+
+crumb :admin_tags do
+  link 'タグ', admin_tags_path
+  parent :admin_dashboard
+end
+
+crumb :edit_admin_tag do |tag|
+  link 'タグ編集', edit_admin_tag_path(tag)
+  parent :admin_dashboard
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -18,6 +18,7 @@
 
 FactoryBot.define do
   factory :tag do
-    
+    sequence(:name) { 'test-tag-1' }
+    sequence(:slug) { 'test-slag-1' }
   end
 end

--- a/spec/system/admin_tags_breadcrumbs_spec.rb
+++ b/spec/system/admin_tags_breadcrumbs_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "AdminTagsBreadcrumbs", type: :system do
+  let(:admin) { create(:user, :admin) }
+  let!(:tag){ create(:tag) }
+
+  describe 'タグ一覧画面にパンくずを表示' do
+    it '正常に表示される' do
+      login(admin)
+      click_link 'タグ'
+      expect(page).to have_link 'Home'
+      expect(page).to have_selector '.current', text: 'タグ'
+    end
+  end
+
+  describe 'タグ編集画面にパンくずを表示' do
+    it '正常に表示される' do
+      login(admin)
+      click_link 'タグ'
+      click_link '編集'
+      expect(page).to have_link 'Home'
+      expect(page).to have_selector '.current', text: 'タグ編集'
+    end
+  end
+end

--- a/spec/system/admin_tags_breadcrumbs_spec.rb
+++ b/spec/system/admin_tags_breadcrumbs_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "AdminTagsBreadcrumbs", type: :system do
       click_link 'タグ'
       click_link '編集'
       expect(page).to have_link 'Home'
+      expect(page).to have_link 'タグ'
       expect(page).to have_selector '.current', text: 'タグ編集'
     end
   end


### PR DESCRIPTION
[Why]
- 管理画面のタグページにパンくずが設定されていない
[Done]
- 既存のパンくずに合わせた設定を行い、管理画面の「タグ一覧ページ」「タグ編集ページ」にパンくずを表示
- 上記を確認するSpecを作成