### PR TITLE
04 add state to article

### DIFF
--- a/app/controllers/admin/articles/publishes_controller.rb
+++ b/app/controllers/admin/articles/publishes_controller.rb
@@ -4,23 +4,29 @@ class Admin::Articles::PublishesController < ApplicationController
   before_action :set_article
 
   def update
-    @article.published_at = Time.current unless @article.published_at?
-    @article.state = :published
-
-    if @article.valid?
-      Article.transaction do
-        @article.body = @article.build_body(self)
-        @article.save!
-      end
-
-      flash[:notice] = '記事を公開しました'
-
+    if @article.published_at > Time.current # 未来の記事
+      @article.state = :publish_wait
+      flash[:notice] = '記事を公開待ちにしました'
       redirect_to edit_admin_article_path(@article.uuid)
-    else
-      flash.now[:alert] = 'エラーがあります。確認してください。'
+    else # 過去の記事
+      @article.published_at = Time.current unless @article.published_at?
+      @article.state = :published
 
-      @article.state = @article.state_was if @article.state_changed?
-      render 'admin/articles/edit'
+      if @article.valid?
+        Article.transaction do
+          @article.body = @article.build_body(self)
+          @article.save!
+        end
+
+        flash[:notice] = '記事を公開しました'
+
+        redirect_to edit_admin_article_path(@article.uuid)
+      else
+        flash.now[:alert] = 'エラーがあります。確認してください。'
+
+        @article.state = @article.state_was if @article.state_changed?
+        render 'admin/articles/edit'
+      end
     end
   end
 

--- a/app/controllers/admin/articles/publishes_controller.rb
+++ b/app/controllers/admin/articles/publishes_controller.rb
@@ -4,7 +4,7 @@ class Admin::Articles::PublishesController < ApplicationController
   before_action :set_article
 
   def update
-    if @article.published_at.to_time > Time.current # 未来の記事
+    if @article.published_at.in_time_zone > Time.current # 未来の記事
       @article.publish_wait!
       flash[:notice] = '記事を公開待ちにしました'
       redirect_to edit_admin_article_path(@article.uuid)

--- a/app/controllers/admin/articles/publishes_controller.rb
+++ b/app/controllers/admin/articles/publishes_controller.rb
@@ -5,12 +5,12 @@ class Admin::Articles::PublishesController < ApplicationController
 
   def update
     if @article.published_at > Time.current # 未来の記事
-      @article.state = :publish_wait
+      @article.publish_wait!
       flash[:notice] = '記事を公開待ちにしました'
       redirect_to edit_admin_article_path(@article.uuid)
     else # 過去の記事
       @article.published_at = Time.current unless @article.published_at?
-      @article.state = :published
+      @article.published!
 
       if @article.valid?
         Article.transaction do

--- a/app/controllers/admin/articles/publishes_controller.rb
+++ b/app/controllers/admin/articles/publishes_controller.rb
@@ -4,7 +4,7 @@ class Admin::Articles::PublishesController < ApplicationController
   before_action :set_article
 
   def update
-    if @article.published_at > Time.current # 未来の記事
+    if @article.published_at.to_time > Time.current # 未来の記事
       @article.publish_wait!
       flash[:notice] = '記事を公開待ちにしました'
       redirect_to edit_admin_article_path(@article.uuid)

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -36,9 +36,6 @@ class Admin::ArticlesController < ApplicationController
 
     if @article.update(article_params)
       unless @article.draft?
-
-        binding.pry
-
         if article_params[:published_at].to_time > Time.current # 未来の記事
           @article.publish_wait!
         elsif article_params[:published_at].to_time <= Time.current # 過去or現在の記事

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -36,9 +36,9 @@ class Admin::ArticlesController < ApplicationController
 
     if @article.update(article_params)
       unless @article.draft?
-        if article_params[:published_at].to_time > Time.current # 未来の記事
+        if article_params[:published_at].in_time_zone > Time.current # 未来の記事
           @article.publish_wait!
-        elsif article_params[:published_at].to_time <= Time.current # 過去or現在の記事
+        elsif article_params[:published_at].in_time_zone <= Time.current # 過去or現在の記事
           @article.published!
         end
       end

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -36,9 +36,12 @@ class Admin::ArticlesController < ApplicationController
 
     if @article.update(article_params)
       unless @article.draft?
-        if article_params[:published_at] > Time.current # 未来の記事
+
+        binding.pry
+
+        if article_params[:published_at].to_time > Time.current # 未来の記事
           @article.publish_wait!
-        elsif article_params[:published_at] <= Time.current # 過去or現在の記事
+        elsif article_params[:published_at].to_time <= Time.current # 過去or現在の記事
           @article.published!
         end
       end

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -36,13 +36,10 @@ class Admin::ArticlesController < ApplicationController
 
     if @article.update(article_params)
       unless @article.draft?
-        if article_params[:published_at] > Time.current
-
-          binding.pry
-
-          @article.state = :publish_wait
-        elsif article_params[:published_at] <= Time.current
-          @article.state = :published
+        if article_params[:published_at] > Time.current # 未来の記事
+          @article.publish_wait!
+        elsif article_params[:published_at] <= Time.current # 過去or現在の記事
+          @article.published!
         end
       end
       flash[:notice] = '更新しました'

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -35,6 +35,16 @@ class Admin::ArticlesController < ApplicationController
     authorize(@article)
 
     if @article.update(article_params)
+      unless @article.draft?
+        if article_params[:published_at] > Time.current
+
+          binding.pry
+
+          @article.state = :publish_wait
+        elsif article_params[:published_at] <= Time.current
+          @article.state = :published
+        end
+      end
       flash[:notice] = '更新しました'
       redirect_to edit_admin_article_path(@article.uuid)
     else

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -70,7 +70,7 @@ class Article < ApplicationRecord
     article_blocks.each do |article_block|
       result << if article_block.sentence?
                   sentence = article_block.blockable
-                  sentence.body || ''
+                  sentence.body ||= ''
                 elsif article_block.medium?
                   medium = ActiveDecorator::Decorator.instance.decorate(article_block.blockable)
                   controller.render_to_string("shared/_media_#{medium.media_type}", locals: { medium: medium }, layout: false)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -39,7 +39,7 @@ class Article < ApplicationRecord
 
   has_one_attached :eye_catch
 
-  enum state: { draft: 0, published: 1 }
+  enum state: { draft: 0, publish_wait: 1, published: 2 }
 
   validates :slug, slug_format: true, uniqueness: true, length: { maximum: 255 }, allow_blank: true
   validates :title, presence: true, uniqueness: true, length: { maximum: 255 }

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -13,6 +13,7 @@ ja:
     article:
       state:
         draft: '下書き'
+        publish_wait: '公開待ち'
         published: '公開'
     medium:
       media_type:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,20 +1,12 @@
-# Use this file to easily define all of your cron jobs.
-#
-# It's helpful, but not entirely necessary to understand cron before proceeding.
-# http://en.wikipedia.org/wiki/Cron
+# Rails.rootを使用するために必要
+require File.expand_path(File.dirname(__FILE__) + "/environment")
+# cronを実行する環境変数
+rails_env = ENV['RAILS_ENV'] || :development
+# cronを実行する環境変数をセット
+set :environment, rails_env
+# cronのログの吐き出し場所
+set :output, "#{Rails.root}/log/cron.log"
 
-# Example:
-#
-# set :output, "/path/to/my/cron_log.log"
-#
-# every 2.hours do
-#   command "/usr/bin/some_great_command"
-#   runner "MyModel.some_method"
-#   rake "some:great:rake:task"
-# end
-#
-# every 4.days do
-#   runner "AnotherModel.prune_old_records"
-# end
-
-# Learn more: http://github.com/javan/whenever
+every 1.hours do
+  rake 'article:publish', environment: :development
+end

--- a/lib/tasks/article.rake
+++ b/lib/tasks/article.rake
@@ -1,0 +1,10 @@
+namespace :article do
+  desc '時間によって記事を公開するタスク'
+  task publish: :environment do
+    Article.publish_wait.each do |article|
+      if article.published_at <= Time.current
+        article.published!
+      end
+    end
+  end
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -28,6 +28,7 @@
 
 FactoryBot.define do
   factory :article do
-
+    sequence(:title) { 'title-1' }
+    sequence(:slug) { 'slug-1' }
   end
 end

--- a/spec/system/admin_articles_previews_spec.rb
+++ b/spec/system/admin_articles_previews_spec.rb
@@ -23,20 +23,17 @@ RSpec.describe "AdminArticlesPreviews", type: :system do
       end
     end
   end
+
   describe '記事作成画面で文章ブロックを追加' do
+    let!(:article) { create(:article) }
     context '文章を入力せずにプレビューを閲覧' do
       it '正常に表示される' do
-        click_link '記事'
-        click_link '新規作成'
-        fill_in 'タイトル', with: 'テスト記事'
-        fill_in 'スラッグ', with: 'test'
-        fill_in '概要',	with: '記事概要'
-        click_button '登録する'
+        visit edit_admin_article_path(article.uuid)
         click_link 'ブロックを追加する'
         click_link '文章'
         click_link 'プレビュー'
         switch_to_window(windows.last)
-        expect(page).to have_content 'テスト記事'
+        expect(page).to have_content article.title
       end
     end
   end


### PR DESCRIPTION
[Now]
- [x] 記事のステータスは、「下書き」「公開」の2種類

[Done]

- [x] 下記の要件で記事の更新、公開ボタンを押した際の挙動を変更する
  - [x] 記事編集画面から「更新する」を押した際に、ステータスが「下書き状態以外」かつ、公開日時が「未来の日付」に設定された場合、 ステータスを「公開待ち」に変更して「更新しました」とフラッシュメッセージを表示
  - [x] 記事編集画面から「更新する」を押した際に、ステータスが「下書き状態以外」かつ、公開日時が「現在または過去の日付」に設定された場合、ステータスを「公開」に変更して「更新しました」とフラッシュメッセージを表示
  - [x]  記事編集画面から「更新する」を押した際に、ステータスが「下書き状態」の場合、ステータスは「下書き」のまま「更新しました」とフラッシュメッセージを表示
  - [x] 記事編集画面から「公開日時が未来の日付の記事」に「公開する」を押した場合、ステータスを「公開待ち」に変更して「記事を公開待ちにしました」とフラッシュメッセージを表示
  - [x] 記事編集画面から「公開日時が過去の日付の記事」に「公開する」を押した場合、ステータスを「公開」に変更して「記事を公開しました」とフラッシュメッセージを表示
- [x] 公開待ち状態で公開日時が過去になっているものがあれば、rakeタスクをライブラリ「whenever」により1時間ごとに走らせ、ステータスを「公開」に変更されるようにする (※ 公開日時が過去で公開待ち状態となっているデータを画面上で更新しなくても、自動でステータスを公開に変更するようにしたい)
- [x]  現状、管理画面から1分単位で公開日時を指定できるようになっているが、1時間ごとに指定できるように変更する (自動更新するcronの実行間隔が1時間毎なので、分単位で設定しても更新できないため)
- [x] cron実行時のログは #{Rails.root}/log/cron.log に出力する
- [x] 上記に対応するSpecの作成