### PR TITLE
05 search article

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -61,7 +61,7 @@ class Admin::ArticlesController < ApplicationController
   end
 
   def search_params
-    params[:q]&.permit(:title, :category_id)
+    params[:q]&.permit(:title, :category_id, :author_id, :tag_id, :body)
   end
 
   def set_article

--- a/app/forms/search_articles_form.rb
+++ b/app/forms/search_articles_form.rb
@@ -3,15 +3,26 @@ class SearchArticlesForm
   include ActiveModel::Attributes
 
   attribute :category_id, :integer
+  attribute :author_id, :integer
+  attribute :tag_id, :integer
   attribute :title, :string
+  attribute :body, :string
 
   def search
     relation = Article.distinct
 
     relation = relation.by_category(category_id) if category_id.present?
+    relation = relation.by_author(author_id) if author_id.present?
+    relation = relation.by_tag(tag_id) if tag_id.present?
+
     title_words.each do |word|
       relation = relation.title_contain(word)
     end
+
+    body_words.each do |word|
+      relation = relation.body_contain(word)
+    end
+
     relation
   end
 
@@ -19,5 +30,9 @@ class SearchArticlesForm
 
   def title_words
     title.present? ? title.split(nil) : []
+  end
+
+  def body_words
+    body.present? ? body.split(nil) : []
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -62,7 +62,10 @@ class Article < ApplicationRecord
   scope :viewable, -> { published.where('published_at < ?', Time.current) }
   scope :new_arrivals, -> { viewable.order(published_at: :desc) }
   scope :by_category, ->(category_id) { where(category_id: category_id) }
+  scope :by_author, ->(author_id) { where(author_id: author_id) }
+  scope :by_tag, ->(tag_id) { joins(:article_tags).where(article_tags: { tag_id: tag_id }) }
   scope :title_contain, ->(word) { where('title LIKE ?', "%#{word}%") }
+  scope :body_contain, ->(word) { joins(:sentences).where('sentences.body LIKE ?', "%#{word}%") }
   scope :past_published, -> { where('published_at <= ?', Time.current) }
 
   def build_body(controller)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -101,6 +101,7 @@ class Article < ApplicationRecord
 
   def adjust_state
     return if draft?
+
     self.state = if publishable?
                    :published
                  else

--- a/app/views/admin/articles/index.html.slim
+++ b/app/views/admin/articles/index.html.slim
@@ -11,8 +11,12 @@
         li
           = form_with model: @search_articles_form, scope: :q, url: admin_articles_path, method: :get, html: { class: 'form-inline' } do |f|
             => f.select :category_id, Category.pluck(:name, :id) , { include_blank: true }, class: 'form-control'
+            => f.select :author_id, Author.pluck(:name, :id) , { include_blank: true }, class: 'form-control'
+            => f.select :tag_id, Tag.pluck(:name, :id) , { include_blank: true }, class: 'form-control'
             .input-group
-              = f.search_field :title, class: 'form-control'
+              = f.search_field :title, class: 'form-control', placeholder: 'タイトル'
+            .input-group
+              = f.search_field :body, class: 'form-control', placeholder: '本文'
               span.input-group-btn
                 = f.submit '検索', class: %w[btn btn-default btn-flat]
         - if policy(Article).new?


### PR DESCRIPTION
[Now]
記事の検索は、セレクトボックスのカテゴリー検索、フリーワードによるタイトル検索の2種類

[Done]
- [x] 著者・タグ・コンテンツ（記事内容）に関しても検索が行えるようにする
- [x] 著者・タグはセレクトボックスによる選択、コンテンツ（記事内容）はフリーワード検索が行えるようにする
- [x] 追加する各検索機能では、下書き状態の記事も検索できるようにする
- [ ] 上記に対応するSpecの作成