### PR TITLE
06 policy settings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,6 +59,6 @@ class ApplicationController < ActionController::Base
   end
 
   def render_403
-    render file: Rails.root.join('public/403.html'), status: 403, layout: false, content_type: 'text/html'
+    render file: Rails.root.join('public/403.html'), status: :forbidden, layout: false, content_type: 'text/html'
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,8 @@ class ApplicationController < ActionController::Base
   before_action :current_site
   before_action :init_components
 
+  rescue_from Pundit::NotAuthorizedError, with: :render_403
+
   def current_site
     @current_site ||= Site.first
   end
@@ -54,5 +56,9 @@ class ApplicationController < ActionController::Base
       new_arrivals: true,
       categories: true
     }
+  end
+
+  def render_403
+    render file: Rails.root.join('public/403.html'), status: 403, layout: false, content_type: 'text/html'
   end
 end

--- a/app/policies/taxonomy_policy.rb
+++ b/app/policies/taxonomy_policy.rb
@@ -1,6 +1,6 @@
 class TaxonomyPolicy < ApplicationPolicy
   def index?
-    true
+    user.admin? || user.editor?
   end
 
   def create?
@@ -8,10 +8,10 @@ class TaxonomyPolicy < ApplicationPolicy
   end
 
   def update?
-    true
+    user.admin? || user.editor?
   end
 
   def destroy?
-    true
+    user.admin? || user.editor?
   end
 end

--- a/public/403.html
+++ b/public/403.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>許可されていません (403)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/404.html -->
+  <div class="dialog">
+    <div>
+      <h1>許可されていません (403)</h1>
+      <p>You may have mistyped the address or the page may have moved.</p>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
+  </div>
+</body>
+</html>

--- a/spec/system/admin_articles_spec.rb
+++ b/spec/system/admin_articles_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "AdminArticles", type: :system do
       expect(page).to have_content future_article_with_sentence.title
       expect(page).not_to have_content future_article_with_another_sentence.title
     end
-    fit '下書き状態の記事について、本文で絞り込み検索ができること' do
+    it '下書き状態の記事について、本文で絞り込み検索ができること' do
       draft_article_with_sentence
       draft_article_with_another_sentence
       visit admin_articles_path

--- a/spec/system/policy_settings_spec.rb
+++ b/spec/system/policy_settings_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe "PolicySettings", type: :system do
+  let(:writer) { create(:user, :writer) }
+  let(:tag) { create(:tag) }
+  let(:author) { create(:author) }
+  let(:category) { create(:category) }
+
+  before do
+    login(writer)
+  end
+
+  describe 'ライターの権限' do
+    it 'タグの一覧表示をしようとすると、403エラーページが表示される' do
+      visit admin_tags_path
+      expect(page).to have_content '403'
+    end
+    it 'タグの編集をしようとすると、403エラーページが表示される' do
+      visit edit_admin_tag_path(tag)
+      expect(page).to have_content '403'
+    end
+    xit 'タグの削除をしようとすると、403エラーページが表示される' do
+      visit admin_tag_path(tag)
+      expect(page).to have_content '403'
+    end
+
+    it '著者の一覧表示をしようとすると、403エラーページが表示される' do
+      visit admin_authors_path
+      expect(page).to have_content '403'
+    end
+    it '著者の編集をしようとすると、403エラーページが表示される' do
+      visit edit_admin_author_path(author)
+      expect(page).to have_content '403'
+    end
+    xit '著者の削除をしようとすると、403エラーページが表示される' do
+      visit admin_author_path(author)
+      expect(page).to have_content '403'
+    end
+
+    it 'カテゴリーの一覧表示をしようとすると、403エラーページが表示される' do
+      visit admin_categories_path
+      expect(page).to have_content '403'
+    end
+    it 'カテゴリーの編集をしようとすると、403エラーページが表示される' do
+      visit edit_admin_category_path(category)
+      expect(page).to have_content '403'
+    end
+    xit 'カテゴリーの削除をしようとすると、403エラーページが表示される' do
+      visit admin_category_path(category)
+      expect(page).to have_content '403'
+    end
+  end
+end


### PR DESCRIPTION
[Now]
- タグ・著者・カテゴリーの作成については、ユーザー権限が管理者もしくは編集者の場合に限られており、ライターは作成することができないが、各項目の一覧表示や編集、削除はライターの権限でも実行できてしまう。
- ライターが権限を許可されていないページにアクセスした場合、サーバーエラーが発生してしまう。

[Done]
- [x] ライターにタグ・著者・カテゴリーの一覧表示・編集・削除をできないようにする。
- [x]  権限エラーが発生した際に、403エラーのページを表示させる(403.htmlは、public配下に新たに作成する)
- [x]  上記に対応するスペックの作成